### PR TITLE
client: ensure channels are closed on __del__()

### DIFF
--- a/aetcd3/client.py
+++ b/aetcd3/client.py
@@ -154,6 +154,10 @@ class Etcd3Client:
 
         self._init_channel_attrs()
 
+    def __del__(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.close())
+
     def _init_channel_attrs(self):
         # These attributes will be assigned during opening of GRPC channel
         self.channel = None


### PR DESCRIPTION
We have found that bad things can happen if 'close()' is not explicitly
called, especially with grpclib raising exceptions due to open channels.

By relying on \_\_del__(), we ensure that we cleanup after ourselves.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>