### PR TITLE
Load ca_cert to validate etcd server certificate

### DIFF
--- a/aetcd3/client.py
+++ b/aetcd3/client.py
@@ -186,6 +186,7 @@ class Etcd3Client:
             else:
                 self.channel._ssl.load_cert_chain(self.ca_cert, keyfile=self.cert_key)
 
+            self.channel._ssl.load_verify_locations(cafile=self.ca_cert)
             self.uses_secure_channel = True
         else:
             self.uses_secure_channel = False


### PR DESCRIPTION
Should load ca_cert as CA certificate for ssl_context to validate etcd server certificate when use ssl