### PR TITLE
Add limit= to get methods, make their signatures more uniform

### DIFF
--- a/aetcd/__init__.py
+++ b/aetcd/__init__.py
@@ -22,6 +22,8 @@ from .rtypes import GetRange  # noqa: F401
 from .rtypes import KeyValue  # noqa: F401
 from .rtypes import Put  # noqa: F401
 from .rtypes import ResponseHeader  # noqa: F401
+from .rtypes import SortOrder  # noqa: F401
+from .rtypes import SortTarget  # noqa: F401
 from .rtypes import Watch  # noqa: F401
 from .watcher import Watcher  # noqa: F401
 from .watcher import WatcherCallback  # noqa: F401

--- a/aetcd/client.py
+++ b/aetcd/client.py
@@ -252,14 +252,20 @@ class Client:
         self,
         key_prefix: bytes,
         limit: int = 0,
-        sort_order: typing.Optional[str] = None,
-        sort_target: str = 'key',
+        sort_order: rtypes.SortOrder = rtypes.SortOrder.NONE,
+        sort_target: rtypes.SortTarget = rtypes.SortTarget.KEY,
         keys_only: bool = False,
     ) -> rtypes.GetRange:
         """Get a range of keys with a prefix from the key-value store.
 
         :param bytes key_prefix:
             Key prefix to get.
+
+        :param aetcd.rtypes.SortOrder sort_order:
+            Order results in :class:`~aetcd.rtypes.SortOrder` direction.
+
+        :param aetcd.rtypes.SortTarget sort_target:
+            Order results by :class:`~aetcd.rtypes.SortTarget`.
 
         :param int limit:
             Limit on the number of keys returned for the request.
@@ -300,8 +306,8 @@ class Client:
         range_start: bytes,
         range_end: bytes,
         limit: int = 0,
-        sort_order: typing.Optional[str] = None,
-        sort_target: str = 'key',
+        sort_order: rtypes.SortOrder = rtypes.SortOrder.NONE,
+        sort_target: rtypes.SortTarget = rtypes.SortTarget.KEY,
         keys_only: bool = False,
     ) -> rtypes.GetRange:
         """Get a range of keys from the key-value store.
@@ -311,6 +317,12 @@ class Client:
 
         :param bytes range_end:
             Last key in range.
+
+        :param aetcd.rtypes.SortOrder sort_order:
+            Order results in :class:`~aetcd.rtypes.SortOrder` direction.
+
+        :param aetcd.rtypes.SortTarget sort_target:
+            Order results by :class:`~aetcd.rtypes.SortTarget`.
 
         :param int limit:
             Limit on the number of keys returned for the request.
@@ -349,11 +361,17 @@ class Client:
     async def get_all(
         self,
         limit: int = 0,
-        sort_order: typing.Optional[str] = None,
-        sort_target: str = 'key',
+        sort_order: rtypes.SortOrder = rtypes.SortOrder.NONE,
+        sort_target: rtypes.SortTarget = rtypes.SortTarget.KEY,
         keys_only: bool = False,
     ) -> rtypes.GetRange:
         """Get all keys from the key-value store.
+
+        :param aetcd.rtypes.SortOrder sort_order:
+            Order results in :class:`~aetcd.rtypes.SortOrder` direction.
+
+        :param aetcd.rtypes.SortTarget sort_target:
+            Order results by :class:`~aetcd.rtypes.SortTarget`.
 
         :param int limit:
             Limit on the number of keys returned for the request.
@@ -1311,8 +1329,8 @@ class Client:
         range_end: typing.Optional[bytes] = None,
         limit: typing.Optional[int] = None,
         revision: typing.Optional[int] = None,
-        sort_order: typing.Optional[str] = None,
-        sort_target: str = 'key',
+        sort_order: rtypes.SortOrder = rtypes.SortOrder.NONE,
+        sort_target: rtypes.SortTarget = rtypes.SortTarget.KEY,
         serializable: bool = False,
         keys_only: bool = False,
         count_only: typing.Optional[int] = None,
@@ -1333,28 +1351,15 @@ class Client:
         if limit is not None:
             range_request.limit = limit
 
-        if sort_order is None:
-            range_request.sort_order = rpc.RangeRequest.NONE
-        elif sort_order == 'ascend':
-            range_request.sort_order = rpc.RangeRequest.ASCEND
-        elif sort_order == 'descend':
-            range_request.sort_order = rpc.RangeRequest.DESCEND
-        else:
-            raise ValueError(f'unknown sort order: {sort_order!r}')
+        range_request.sort_order = getattr(
+            rpc.RangeRequest.SortOrder,
+            rtypes.SortOrder(sort_order).name,
+        )
 
-        if sort_target is None or sort_target == 'key':
-            range_request.sort_target = rpc.RangeRequest.KEY
-        elif sort_target == 'version':
-            range_request.sort_target = rpc.RangeRequest.VERSION
-        elif sort_target == 'create':
-            range_request.sort_target = rpc.RangeRequest.CREATE
-        elif sort_target == 'mod':
-            range_request.sort_target = rpc.RangeRequest.MOD
-        elif sort_target == 'value':
-            range_request.sort_target = rpc.RangeRequest.VALUE
-        else:
-            raise ValueError('sort_target must be one of "key", '
-                             '"version", "create", "mod" or "value"')
+        range_request.sort_target = getattr(
+            rpc.RangeRequest.SortTarget,
+            rtypes.SortTarget(sort_target).name,
+        )
 
         range_request.serializable = serializable
         range_request.keys_only = keys_only

--- a/aetcd/rtypes.py
+++ b/aetcd/rtypes.py
@@ -15,6 +15,42 @@ class _Slotted:
         ) + ']'
 
 
+class SortOrder(enum.Enum):
+    #: No sort order.
+    NONE = enum.auto()
+
+    #: Ascending sort order - lowest target value first.
+    ASCEND = enum.auto()
+
+    #: Descending sort order - highest target value first.
+    DESCEND = enum.auto()
+
+
+class SortTarget(enum.Enum):
+    #: Sort range operation results by key.
+    KEY = enum.auto()
+
+    #: Sort range operation results by key version.
+    VERSION = enum.auto()
+
+    #: Sort range operation results by revision of the last creation on the key.
+    CREATE = enum.auto()
+
+    #: Sort range operation results by revision of the last modification on the key.
+    MOD = enum.auto()
+
+    #: Sort range operation results by value.
+    VALUE = enum.auto()
+
+
+class EventKind(enum.Enum):
+    #: Designates a ``PUT`` event.
+    PUT = enum.auto()
+
+    #: Designates a ``DELETE`` event.
+    DELETE = enum.auto()
+
+
 class ResponseHeader(_Slotted):
     """Represents the metadata for the response."""
 
@@ -233,14 +269,6 @@ class DeleteRange:
         )
 
 
-class EventKind(str, enum.Enum):
-    #: Designates a ``PUT`` event.
-    PUT = 'PUT'
-
-    #: Designates a ``DELETE`` event.
-    DELETE = 'DELETE'
-
-
 class Event(_Slotted):
     """Reperesents a watch event."""
 
@@ -251,11 +279,11 @@ class Event(_Slotted):
     ]
 
     def __init__(self, kind, kv, prev_kv=None):
-        #: The kind of event. If the type is a ``PUT``, it indicates
-        #: new data has been stored to the key. If the type is a ``DELETE``,
-        #: it indicates the key was deleted.
-        self.kind: EventKind = rpc.Event.EventType.DESCRIPTOR.values_by_number[
-            kind].name
+        #: The kind of event.
+        #: ``PUT`` indicates that new data has been stored to the key.
+        #: ``DELETE`` indicates the key was deleted.
+        self.kind: EventKind = EventKind[
+            rpc.Event.EventType.DESCRIPTOR.values_by_number[kind].name]
 
         #: Holds the key-value for the event.
         #: A ``PUT`` event contains current key-value pair.

--- a/tests/integration/test_kv.py
+++ b/tests/integration/test_kv.py
@@ -7,6 +7,7 @@ import subprocess
 
 import pytest
 
+import aetcd
 import aetcd.exceptions
 import aetcd.rpc
 
@@ -152,7 +153,7 @@ async def test_get_range_with_sort_order(etcdctl, etcd):
         etcdctl('put', f'/key{k}', v)
 
     keys = b''
-    for result in await etcd.get_prefix(b'/key', sort_order='ascend'):
+    for result in await etcd.get_prefix(b'/key', sort_order=aetcd.SortOrder.ASCEND):
         keys += remove_prefix(result.key, b'/key')
 
     assert keys == initial_keys.encode('utf-8')
@@ -160,7 +161,7 @@ async def test_get_range_with_sort_order(etcdctl, etcd):
     reverse_keys = b''
     for result in await etcd.get_prefix(
         b'/key',
-        sort_order='descend',
+        sort_order=aetcd.SortOrder.DESCEND,
     ):
         reverse_keys += remove_prefix(result.key, b'/key')
 

--- a/tests/integration/test_kv.py
+++ b/tests/integration/test_kv.py
@@ -84,6 +84,19 @@ async def test_get_prefix_with_keys_only(etcdctl, etcd):
 
 
 @pytest.mark.asyncio
+async def test_get_prefix_with_limit(etcdctl, etcd):
+    for i in range(10):
+        etcdctl('put', f'/inrange{i}', 'in range')
+
+    results = list(await etcd.get_prefix(b'/inrange', limit=3))
+
+    assert len(results) == 3
+    for result in results:
+        assert result.key.startswith(b'/inrange')
+        assert result.value == b'in range'
+
+
+@pytest.mark.asyncio
 async def test_get_range(etcdctl, etcd):
     for char in string.ascii_lowercase:
         if char < 'p':
@@ -95,6 +108,35 @@ async def test_get_range(etcdctl, etcd):
 
     assert len(results) == 15
     for result in results:
+        assert result.value == b'in range'
+
+
+@pytest.mark.asyncio
+async def test_get_range_with_keys_only(etcdctl, etcd):
+    for i in range(20):
+        etcdctl('put', f'/inrange{i}', 'in range')
+
+    for i in range(5):
+        etcdctl('put', f'/notinrange{i}', 'not in range')
+
+    results = list(await etcd.get_range(b'/inrange', b'/inrangf', keys_only=True))
+
+    assert len(results) == 20
+    for result in results:
+        assert result.key.startswith(b'/inrange')
+        assert not result.value
+
+
+@pytest.mark.asyncio
+async def test_get_range_with_limit(etcdctl, etcd):
+    for i in range(10):
+        etcdctl('put', f'/inrange{i}', 'in range')
+
+    results = list(await etcd.get_range(b'/inrange', b'/inrangf', limit=3))
+
+    assert len(results) == 3
+    for result in results:
+        assert result.key.startswith(b'/inrange')
         assert result.value == b'in range'
 
 
@@ -153,6 +195,32 @@ async def test_get_all(etcdctl, etcd):
 async def test_get_all_not_found(etcd):
     result = list(await etcd.get_all())
     assert not result
+
+
+@pytest.mark.asyncio
+async def test_get_all_with_keys_only(etcdctl, etcd):
+    for i in range(10):
+        etcdctl('put', f'/inrange{i}', 'in range')
+
+    results = list(await etcd.get_all(keys_only=True))
+
+    assert len(results) == 10
+    for result in results:
+        assert result.key.startswith(b'/inrange')
+        assert not result.value
+
+
+@pytest.mark.asyncio
+async def test_get_all_with_limit(etcdctl, etcd):
+    for i in range(10):
+        etcdctl('put', f'/inrange{i}', 'in range')
+
+    results = list(await etcd.get_all(limit=3))
+
+    assert len(results) == 3
+    for result in results:
+        assert result.key.startswith(b'/inrange')
+        assert result.value == b'in range'
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+import aetcd
 import aetcd.client
 import aetcd.rpc
 
@@ -15,12 +16,9 @@ def test_auth_with_no_username_or_password():
 def test__build_get_range_request_sort_target():
     key = b'key'
     sort_targets = {
-        None: aetcd.rpc.RangeRequest.KEY,
-        'key': aetcd.rpc.RangeRequest.KEY,
-        'version': aetcd.rpc.RangeRequest.VERSION,
-        'create': aetcd.rpc.RangeRequest.CREATE,
-        'mod': aetcd.rpc.RangeRequest.MOD,
-        'value': aetcd.rpc.RangeRequest.VALUE,
+        aetcd.SortTarget.KEY: aetcd.rpc.RangeRequest.KEY,
+        aetcd.SortTarget.CREATE: aetcd.rpc.RangeRequest.CREATE,
+        aetcd.SortTarget.MOD: aetcd.rpc.RangeRequest.MOD,
     }
 
     for sort_target, expected_sort_target in sort_targets.items():
@@ -31,15 +29,18 @@ def test__build_get_range_request_sort_target():
         assert range_request.sort_target == expected_sort_target
 
     with pytest.raises(ValueError):
-        aetcd.client.Client._build_get_range_request(key, sort_target='unknown')
+        aetcd.client.Client._build_get_range_request(key, sort_target='KEY')
+
+    with pytest.raises(ValueError):
+        aetcd.client.Client._build_get_range_request(key, sort_target=None)
 
 
 def test__build_get_range_request_sort_order():
     key = b'key'
     sort_orders = {
-        None: aetcd.rpc.RangeRequest.NONE,
-        'ascend': aetcd.rpc.RangeRequest.ASCEND,
-        'descend': aetcd.rpc.RangeRequest.DESCEND,
+        aetcd.SortOrder.NONE: aetcd.rpc.RangeRequest.NONE,
+        aetcd.SortOrder.ASCEND: aetcd.rpc.RangeRequest.ASCEND,
+        aetcd.SortOrder.DESCEND: aetcd.rpc.RangeRequest.DESCEND,
     }
 
     for sort_order, expected_sort_order in sort_orders.items():
@@ -50,7 +51,10 @@ def test__build_get_range_request_sort_order():
         assert range_request.sort_order == expected_sort_order
 
     with pytest.raises(ValueError):
-        aetcd.client.Client._build_get_range_request(key, sort_order='unknown')
+        aetcd.client.Client._build_get_range_request(key, sort_order='ASCEND')
+
+    with pytest.raises(ValueError):
+        aetcd.client.Client._build_get_range_request(key, sort_order=None)
 
 
 def test__ops_to_requests():


### PR DESCRIPTION
- Adding one missing request parameters, one key at a time...

- Ordered keys to be more like rpc.proto, maybe e.g. `get_range(self, range_start, range_end, *, ...)` in all sigs can be used to avoid such ordering/additions ever breaking code in the future, but guessing it's not an issue atm anyway.

- Added docstrings for couple parameters where they were missing, but dunno how these should look for sort_order and such enums, so skipped these here.

- get_all() was missing type annotations.
