### PR TITLE
Raise RuntimeError if watcher.cancel() is called after client.close()

### DIFF
--- a/aetcd/client.py
+++ b/aetcd/client.py
@@ -644,12 +644,16 @@ class Client:
         canceled = asyncio.Event()
 
         async def cancel():
+            if not self._watcher:
+                raise RuntimeError('Calling watcher.cancel() on a closed client')
             canceled.set()
             await events.put(None)
             await self._watcher.cancel(watcher_callback.watch_id)
 
         @_handle_errors
         async def iterator():
+            if not self._watcher:
+                raise RuntimeError('Using watcher as iterator on a closed client')
             while not canceled.is_set():
                 event = await events.get()
                 if event is None:

--- a/aetcd/rtypes.py
+++ b/aetcd/rtypes.py
@@ -269,10 +269,15 @@ class Event(_Slotted):
 
 
 class Watch:
-    """Reperesents the result of a watch operation.
+    """Represents the result of a watch operation.
 
-    To get emitted events use as an asynchronous iterator, emitted events are
-    instances of an :class:`~aetcd.rtypes.Event`.
+    Use as an asynchronous iterator to get emitted events.
+    Events are instances of an :class:`~aetcd.rtypes.Event`.
+    Such iterator is exhausted either when undelying :class:`~aetcd.client.Client`
+    is closed or cancel method is called on this instance.
+
+    Instance must not be used after underlying :class:`~aetcd.client.Client`
+    is closed, and doing so will raise RuntimeError.
 
     Usage example:
 


### PR DESCRIPTION
Currently client.watch() will return a watcher object that can be used separately from the client.
Current behavior when watcher.close() is called after client.close() - `AttributeError: 'NoneType' object has no attribute 'cancel'` - is confusing and unclear.

I think two ways to handle this better are:

- Make watcher.cancel() a no-op after client is closed.
  This mimics how `async for kv in watcher:` iterator currently works.

- Have watcher.cancel() raise a clear "must not be called when client is already closed" exception.

This PR does the latter, assuming that it is a programming error to call watcher.cancel() for closed client.
In my use-case closing the client should cancel all watcher iterators already, so such call indeed indicates some code bug.
Picked RuntimeError because it's used for same types of bugs in asyncio itself and also in client.py already, and there should never be a need to handle it in any way (i.e. handling RuntimeError is almost certainly a bug in the code).

Alternative viewpoint on the API can be that `w = client.watch(); try: ... finally: w.cancel()` pattern should be supported, in which case .cancel() should be a no-op (to avoid raising exception in "finally").
If this is the case, rtypes.Watch should also support aenter/aexit to work in a more conventional `with client.watch() as w: ...` pattern. Assuming that this is not implemented on purpose, RuntimeError variant above seem to be a more fitting option.
