### PR TITLE
Add duplicate lease exception

### DIFF
--- a/aetcd/__init__.py
+++ b/aetcd/__init__.py
@@ -5,6 +5,7 @@ from .client import Transactions  # noqa: F401
 from .exceptions import ClientError  # noqa: F401
 from .exceptions import ConnectionFailedError  # noqa: F401
 from .exceptions import ConnectionTimeoutError  # noqa: F401
+from .exceptions import DuplicateLeaseError  # noqa: F401
 from .exceptions import InternalError  # noqa: F401
 from .exceptions import InvalidArgumentError  # noqa: F401
 from .exceptions import PreconditionFailedError  # noqa: F401

--- a/tests/integration/test_lease.py
+++ b/tests/integration/test_lease.py
@@ -2,6 +2,8 @@ import asyncio
 
 import pytest
 
+import aetcd.exceptions
+
 
 @pytest.mark.asyncio
 async def test_lease_grant(etcd):
@@ -44,3 +46,11 @@ async def test_lease_expire(etcd):
     await asyncio.sleep((await lease.granted_ttl()) + 1)
     result = await etcd.get(key)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lease_create_with_already_existing_id(etcd):
+    await etcd.lease(10, lease_id=123)
+
+    with pytest.raises(aetcd.exceptions.DuplicateLeaseError):
+        await etcd.lease(15, lease_id=123)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -67,3 +67,23 @@ def test__handle_exception_with_unknown_errors(rpc_error):
 
     with pytest.raises(aetcd.exceptions.ClientError, match='unknown error'):
         aetcd.exceptions._handle_exception(error)
+
+
+def test__handle_exception_with_duplicate_lease_error(rpc_error):
+    error = rpc_error(
+        code=aetcd.rpc.StatusCode.FAILED_PRECONDITION,
+        details='etcdserver: lease already exists',
+    )
+
+    with pytest.raises(aetcd.exceptions.DuplicateLeaseError):
+        aetcd.exceptions._handle_exception(error)
+
+
+def test__handle_exception_with_duplicate_lease_error_and_internal_rpc_error(rpc_error):
+    error = rpc_error(
+        code=aetcd.rpc.StatusCode.INTERNAL,
+        details='etcdserver: lease already exists',
+    )
+
+    with pytest.raises(aetcd.exceptions.InternalError):
+        aetcd.exceptions._handle_exception(error)


### PR DESCRIPTION
`DuplicateLeaseError` will be thrown in case one creates lease with already existing id