### PR TITLE
Fix _out_quorum fixture

### DIFF
--- a/tests/integration/test_kv.py
+++ b/tests/integration/test_kv.py
@@ -13,7 +13,7 @@ import aetcd.rpc
 
 @contextlib.contextmanager
 def _out_quorum():
-    pids = subprocess.check_output(['pgrep', '-f', '--', '--name pifpaf[12]'])
+    pids = subprocess.check_output(['pgrep', '-f', '--', 'pifpaf[12]'])
     pids = [int(pid.strip()) for pid in pids.splitlines()]
     try:
         for pid in pids:


### PR DESCRIPTION
On my laptop with `pgrep from procps-ng 3.3.17` pgrep says:

```
pgrep: unrecognized option '--name'
```