### PR TITLE
Run pifpaf in debug mode and test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: bootstrap
 	$(PYTHON) -m pytest
 
 testcluster: bootstrap
-	$(PYTHON) -m pifpaf -e TEST run etcd --cluster -- $(PYTHON) -m pytest --cov-report=xml
+	$(PYTHON) -m pifpaf -e TEST --debug run etcd --cluster -- $(PYTHON) -m pytest --timeout=60 --cov-report=xml
 
 testreport: bootstrap
 	$(PYTHON) -m pytest --cov-report=html

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
             'pytest-asyncio==0.20.3',
             'pytest-cov==4.0.0',
             'pytest-mock==3.10.0',
+            'pytest-timeout==2.1.0',
             'pytest==7.2.1',
         ],
     },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,7 @@ def etcdctl():
         if endpoint:
             args = ['--endpoints', endpoint] + list(args)
         args = ['etcdctl', '-w', 'json'] + list(args)
-        output = subprocess.check_output(args)
+        output = subprocess.check_output(args, timeout=5)
         if ignore_result:
             return None
         return json.loads(output.decode('utf-8'))


### PR DESCRIPTION
In order to understand why tests hang up from time to time, I suggest to enable pifpaf's debug logs for a while and find the reason there. 