### PR TITLE
Replace sync subprocess call with async version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
     branches: ['master']
 
   schedule:
-    # Daily at 4 AM UTC
-    - cron: '0 4 * * *'
+    # Every hour
+    - cron: '0 * * * *'
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: bootstrap
 	$(PYTHON) -m pytest
 
 testcluster: bootstrap
-	$(PYTHON) -m pifpaf -e TEST run etcd --cluster -- $(PYTHON) -m pytest --cov-report=xml
+	$(PYTHON) -m pifpaf -e TEST --debug run etcd --cluster -- $(PYTHON) -m pytest --timeout=60 --cov-report=xml
 
 testreport: bootstrap
 	$(PYTHON) -m pytest --cov-report=html

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ application-import-names = aetcd
 [tool:pytest]
 addopts =
     --cov=aetcd
+    --timeout=30
     tests
 asyncio_mode = auto
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
             'pytest-asyncio==0.20.3',
             'pytest-cov==4.0.0',
             'pytest-mock==3.10.0',
+            'pytest-timeout==2.1.0',
             'pytest==7.2.1',
         ],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,15 @@ import aetcd
 import aetcd.rpc
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        '--with-cluster',
+        action='store_true',
+        default=False,
+        help='Run tests with ETCD cluster',
+    )
+
+
 @pytest.fixture
 async def etcd():
     # TODO: Rewrite the mock and related tests without side-effects

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -3,16 +3,17 @@ import pytest
 import aetcd
 
 
+@pytest.mark.asyncio
 @pytest.fixture
-def etcd_auth(etcdctl):
-    etcdctl('user', 'add', 'root:pwd')
-    etcdctl('auth', 'enable', ignore_result=True)
+async def etcd_auth(etcdctl):
+    await etcdctl('user', 'add', 'root:pwd')
+    await etcdctl('auth', 'enable', ignore_result=True)
 
     yield
 
-    etcdctl('--user', 'root:pwd', 'auth', 'disable', ignore_result=True)
-    etcdctl('role', 'delete', 'root')
-    etcdctl('user', 'delete', 'root')
+    await etcdctl('--user', 'root:pwd', 'auth', 'disable', ignore_result=True)
+    await etcdctl('role', 'delete', 'root')
+    await etcdctl('user', 'delete', 'root')
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -1,6 +1,10 @@
 import pytest
 
 
+@pytest.mark.skipif(
+    "config.getoption('--with-cluster') is False",
+    reason='ETCD cluster was not run',
+)
 @pytest.mark.asyncio
 async def test_member_list(etcd):
     assert len([m async for m in etcd.members()]) == 3

--- a/tests/integration/test_kv.py
+++ b/tests/integration/test_kv.py
@@ -26,21 +26,25 @@ def _out_quorum():
 
 @pytest.mark.asyncio
 async def test_get_key(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
     result = await etcd.get(b'/key')
     assert result.value == b'value'
 
 
 @pytest.mark.asyncio
 async def test_get_key_has_revision(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
     result = await etcd.get(b'/key')
     assert result.header.revision > 0
 
 
+@pytest.mark.skipif(
+    "config.getoption('--with-cluster') is False",
+    reason='ETCD cluster was not run',
+)
 @pytest.mark.asyncio
 async def test_get_key_with_serializable(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
     with _out_quorum():
         result = await etcd.get(b'/key', serializable=True)
     assert result.value == b'value'
@@ -55,10 +59,10 @@ async def test_get_key_unknown(etcd):
 @pytest.mark.asyncio
 async def test_get_prefix(etcdctl, etcd):
     for i in range(20):
-        etcdctl('put', f'/inrange{i}', 'in range')
+        await etcdctl('put', f'/inrange{i}', 'in range')
 
     for i in range(5):
-        etcdctl('put', f'/notinrange{i}', 'not in range')
+        await etcdctl('put', f'/notinrange{i}', 'not in range')
 
     results = list(await etcd.get_prefix(b'/inrange'))
 
@@ -70,10 +74,10 @@ async def test_get_prefix(etcdctl, etcd):
 @pytest.mark.asyncio
 async def test_get_prefix_with_keys_only(etcdctl, etcd):
     for i in range(20):
-        etcdctl('put', f'/inrange{i}', 'in range')
+        await etcdctl('put', f'/inrange{i}', 'in range')
 
     for i in range(5):
-        etcdctl('put', f'/notinrange{i}', 'not in range')
+        await etcdctl('put', f'/notinrange{i}', 'not in range')
 
     results = list(await etcd.get_prefix(b'/inrange', keys_only=True))
 
@@ -87,9 +91,9 @@ async def test_get_prefix_with_keys_only(etcdctl, etcd):
 async def test_get_range(etcdctl, etcd):
     for char in string.ascii_lowercase:
         if char < 'p':
-            etcdctl('put', '/key' + char, 'in range')
+            await etcdctl('put', '/key' + char, 'in range')
         else:
-            etcdctl('put', '/key' + char, 'not in range')
+            await etcdctl('put', '/key' + char, 'not in range')
 
     results = list(await etcd.get_range(b'/keya', b'/keyp'))
 
@@ -107,7 +111,7 @@ async def test_get_range_with_sort_order(etcdctl, etcd):
     initial_values = 'qwert'
 
     for k, v in zip(initial_keys, initial_values):
-        etcdctl('put', f'/key{k}', v)
+        await etcdctl('put', f'/key{k}', v)
 
     keys = b''
     for result in await etcd.get_prefix(b'/key', sort_order='ascend'):
@@ -128,7 +132,7 @@ async def test_get_range_with_sort_order(etcdctl, etcd):
 @pytest.mark.asyncio
 async def test_get_range_not_found(etcdctl, etcd):
     for i in range(5):
-        etcdctl('put', f'/inrange{i}', 'not in range')
+        await etcdctl('put', f'/inrange{i}', 'not in range')
 
     results = list(await etcd.get_prefix(b'/notinrange'))
     assert not results
@@ -137,10 +141,10 @@ async def test_get_range_not_found(etcdctl, etcd):
 @pytest.mark.asyncio
 async def test_get_all(etcdctl, etcd):
     for i in range(20):
-        etcdctl('put', f'/inrange{i}', 'value')
+        await etcdctl('put', f'/inrange{i}', 'value')
 
     for i in range(5):
-        etcdctl('put', f'/notinrange{i}', 'value')
+        await etcdctl('put', f'/notinrange{i}', 'value')
 
     results = list(await etcd.get_all())
 
@@ -158,7 +162,7 @@ async def test_get_all_not_found(etcd):
 @pytest.mark.asyncio
 async def test_put_key(etcdctl, etcd):
     await etcd.put(b'/key', b'value')
-    result = etcdctl('get', '/key')
+    result = await etcdctl('get', '/key')
     assert base64.b64decode(result['kvs'][0]['value']) == b'value'
 
 
@@ -170,14 +174,14 @@ async def test_put_key_has_revision(etcd):
 
 @pytest.mark.asyncio
 async def test_put_key_with_prev_kv(etcdctl, etcd):
-    etcdctl('put', '/key', 'old_value')
+    await etcdctl('put', '/key', 'old_value')
     result = await etcd.put(b'/key', b'value', prev_kv=True)
     assert result.prev_kv.value == b'old_value'
 
 
 @pytest.mark.asyncio
 async def test_delete_key(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
 
     result = await etcd.get(b'/key')
     assert result.value == b'value'
@@ -195,7 +199,7 @@ async def test_delete_key(etcdctl, etcd):
 
 @pytest.mark.asyncio
 async def test_delete_key_has_revision(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
 
     result = await etcd.delete(b'/key')
     assert result.header.revision > 0
@@ -203,7 +207,7 @@ async def test_delete_key_has_revision(etcdctl, etcd):
 
 @pytest.mark.asyncio
 async def test_delete_key_with_prev_kv(etcdctl, etcd):
-    etcdctl('put', '/key', 'old_value')
+    await etcdctl('put', '/key', 'old_value')
     result = await etcd.delete(
         b'/key',
         prev_kv=True,
@@ -214,8 +218,8 @@ async def test_delete_key_with_prev_kv(etcdctl, etcd):
 
 @pytest.mark.asyncio
 async def test_delete_prefix_keys(etcdctl, etcd):
-    etcdctl('put', '/key1', 'value1')
-    etcdctl('put', '/key2', 'value2')
+    await etcdctl('put', '/key1', 'value1')
+    await etcdctl('put', '/key2', 'value2')
 
     result = await etcd.get(b'/key1')
     assert result.value == b'value1'
@@ -235,8 +239,8 @@ async def test_delete_prefix_keys(etcdctl, etcd):
 
 @pytest.mark.asyncio
 async def test_delete_prefix_keys_with_prev_kv(etcdctl, etcd):
-    etcdctl('put', '/key1', 'value1')
-    etcdctl('put', '/key2', 'value2')
+    await etcdctl('put', '/key1', 'value1')
+    await etcdctl('put', '/key2', 'value2')
 
     response = await etcd.delete_prefix(b'/key', prev_kv=True)
     assert response.deleted == 2
@@ -256,7 +260,7 @@ async def test_delete_range_keys(etcdctl, etcd):
         '/key3\1': 'value30',
         '/key4': 'value4',
     }.items():
-        etcdctl('put', k, v)
+        await etcdctl('put', k, v)
 
     result = await etcd.get(b'/key2')
     assert result.value == b'value2'
@@ -282,8 +286,8 @@ async def test_delete_range_keys(etcdctl, etcd):
 
 @pytest.mark.asyncio
 async def test_delete_range_keys_with_prev_kv(etcdctl, etcd):
-    etcdctl('put', '/key1', 'value1')
-    etcdctl('put', '/key2', 'value2')
+    await etcdctl('put', '/key1', 'value1')
+    await etcdctl('put', '/key2', 'value2')
 
     response = await etcd.delete_range(b'/key1', b'/key3', prev_kv=True)
     assert response.deleted == 2
@@ -313,25 +317,25 @@ async def test_replace_fail(etcd):
 
 @pytest.mark.asyncio
 async def test_transaction_success(etcdctl, etcd):
-    etcdctl('put', '/key', 'value')
+    await etcdctl('put', '/key', 'value')
     await etcd.transaction(
         compare=[etcd.transactions.value(b'/key') == b'value'],
         success=[etcd.transactions.put(b'/key', b'success')],
         failure=[etcd.transactions.put(b'/key', b'failure')],
     )
-    result = etcdctl('get', '/key')
+    result = await etcdctl('get', '/key')
     assert base64.b64decode(result['kvs'][0]['value']) == b'success'
 
 
 @pytest.mark.asyncio
 async def test_transaction_failure(etcdctl, etcd):
-    etcdctl('put', '/key', 'value1')
+    await etcdctl('put', '/key', 'value1')
     await etcd.transaction(
         compare=[etcd.transactions.value(b'/key') == b'value2'],
         success=[etcd.transactions.put(b'/key', b'success')],
         failure=[etcd.transactions.put(b'/key', b'failure')],
     )
-    result = etcdctl('get', '/key')
+    result = await etcdctl('get', '/key')
     assert base64.b64decode(result['kvs'][0]['value']) == b'failure'
 
 

--- a/tests/integration/test_maintenance.py
+++ b/tests/integration/test_maintenance.py
@@ -82,4 +82,4 @@ async def test_snapshot(etcdctl, etcd):
         await etcd.snapshot(f)
         f.flush()
 
-        etcdctl('snapshot', 'status', f.name)
+        await etcdctl('snapshot', 'status', f.name)


### PR DESCRIPTION
- Remove threads from tests
- Skip some tests which require ETCD cluster during running `make test` and `make testreport`
- Add 60 second  timeout for each test via pytest-timeout
- Run pifpaf in debug mode