### PR TITLE
Add etcd 3.4 and 3.5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        etcd: ['3.3.27']
+        etcd: ['3.3.27', '3.4.23', '3.5.7']
         os: ['ubuntu-20.04']
         python: ['3.8', '3.9', '3.10', '3.11']
     steps:

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setuptools.setup(
             'sphinx_rtd_theme==1.2.0',
         ],
         'test': [
-            'pifpaf==3.1.5',
+            'pifpaf @ git+https://github.com/jd/pifpaf.git@80cc13bd7e4b0cb286d15659c9fe7958e8600cd9#egg=aetcd',
             'pytest-asyncio==0.20.3',
             'pytest-cov==4.0.0',
             'pytest-mock==3.10.0',


### PR DESCRIPTION
* Use latest pifpaf version (from master) in order to support ETCD 3.4. More details here: https://github.com/jd/pifpaf/issues/127