### PR TITLE
Add keepalive ETCD client settings in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,7 +68,11 @@ async def client(etcdctl):
             username=username,
             password=password,
             timeout=timeout,
-            options=options,
+            options={
+                'keepalive_time_ms': 6000,
+                'keepalive_permit_without_calls': True,
+                'http2_max_pings_without_data': 0,
+            },
         ) as client:
             yield client
 


### PR DESCRIPTION
According to these logs https://github.com/martyanov/aetcd/actions/runs/4673902116/jobs/8277584010#step:6:307 

```
DEBUG [pifpaf.drivers] etcd[1958] output: WARNING: 2023/04/12 02:18:06 grpc: Server.Serve failed to create ServerTransport:  connection error: desc = "transport: http2Server.HandleStreams failed to read initial settings frame: read tcp 127.0.0.1:2379->127.0.0.1:51674: read: connection reset by peer"
DEBUG [pifpaf.drivers] etcd[1958] output: WARNING: 2023/04/12 02:18:07 grpc: Server.Serve failed to create ServerTransport:  EOF
```
etcd client drops connection to the server. 

Hence, I suggest to add keepalive settings to a client in the integration tests.